### PR TITLE
buf zero fix for batches

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -1237,6 +1237,9 @@ fn fixup_write_read_return_buffers(requests: &mut [WriteReadRequest]) {
     // Go through the buffers in reverse order.
     for i in (0..requests.len()).rev() {
         let (my_initial, my_actual, _, mut size) = offsets[i];
+        if size == 0 {
+            continue;
+        };
         if my_initial == my_actual {
             // Offsets match, no further action required since all
             // previous buffers must be of full length too.


### PR DESCRIPTION
When calling GET_SYMINFO_BYNAME_EX for non-existing variables, TwinCAT servers sometimes respond with no error but with invalid data block instead. This makes fixup_write_read_return_buffers crash.

The suggested quick-fix solves the problem.