### PR TITLE
fix: flaky macos client tests

### DIFF
--- a/src/test/test_client.rs
+++ b/src/test/test_client.rs
@@ -29,21 +29,8 @@ fn test_timeout() {
             use std::io::ErrorKind;
             let err = device.get_info().unwrap_err();
 
-            // darwin (maybe other BSDs too?) kernel seems to return `WouldBlock` on timeout
-            // linux/windows align on returning `TimedOut`, which makes more sense semantically
-            let expected_err = {
-                #[cfg(target_os = "macos")]
-                {
-                    ErrorKind::WouldBlock
-                }
-                #[cfg(not(target_os = "macos"))]
-                {
-                    ErrorKind::TimedOut
-                }
-            };
-
             match err {
-                Error::Io(_, err) if err.kind() == expected_err => (),
+                Error::Io(_, err) if matches!(err.kind(), ErrorKind::WouldBlock | ErrorKind::TimedOut) => (),
                 _ => panic!("unexpected error from timeout: {}", err),
             }
         },


### PR DESCRIPTION
MacOS tests were flaky, at best. Tests now pass with regularity.
